### PR TITLE
fix(core): Fix .js files regex to catch filenames in the form of [name].js?[chunkhash]

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ export default class ButternutPlugin {
           const files = chunk.files
 
           for (const file of files) {
-            const matchObjectConfiguration = { test: /\.js$/ }
+            const matchObjectConfiguration = { test: /\.js($|\?)/i }
 
             if (ModuleFilenameHelpers.matchObject(matchObjectConfiguration, file)) {
               const asset = compilation.assets[file]


### PR DESCRIPTION
Explanation of the problem: https://github.com/webpack/react-starter/issues/9\#issuecomment-58561637

Precedent on internal webpack uglifyjs plugin:
https://github.com/webpack/webpack/commit/2d3b2dc4f79dc2a020a5aafb2776aa36ab429d75 https://github.com/webpack/webpack/commit/8bbc81f635c2ee34d53d231ce92b1a94d7abb912